### PR TITLE
Update package.json to match license

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mdi-vue3",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "version": "7.4.47",
   "description": "Mirror of @mdi/js exported as self-contained Vue components",
   "keywords": [


### PR DESCRIPTION
The package.json file now matches the published license.
Should've added this in the previous PR, my bad. 